### PR TITLE
Assign the returned entity in new action

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -297,7 +297,7 @@ class AdminController extends Controller
         if ($newForm->isSubmitted() && $newForm->isValid()) {
             if ($dto) {
                 $callable = $this->container->get('easyadmin.dto_entity_callable_storage')->getCallable($this->entity['name'], 'new');
-                $callable($dto, null, 'new');
+                $entity = $callable($dto, null, 'new');
             }
 
             $this->dispatch(EasyAdminEvents::PRE_PERSIST, ['entity' => $entity]);


### PR DESCRIPTION
This prevents passing null instead of an entity to `persist()`.